### PR TITLE
Feature/multiple interactions

### DIFF
--- a/src/main/java/game/App.java
+++ b/src/main/java/game/App.java
@@ -13,6 +13,7 @@ import game.display.Display;
 import game.gamelogic.Armed;
 import game.gamelogic.Armored;
 import game.gamelogic.HasInventory;
+import game.gamelogic.HasOffHand;
 import game.gamelogic.abilities.HasAbilities;
 import game.gamelogic.abilities.HasAbility;
 import game.gamelogic.abilities.HasPassives;
@@ -86,6 +87,10 @@ public class App
                 if (conditions.includesUnarmedWeapon())
                     helper.accept(entity.getUnarmedWeapon());
 
+            }
+
+            if (object instanceof HasOffHand hoh && conditions.includesOffHand()) {
+                helper.accept(hoh.getOffHandSlot().getEquippedItem());
             }
 
             if (object instanceof HasInventory hasInventory && conditions.includesInventory())

--- a/src/main/java/game/CheckConditions.java
+++ b/src/main/java/game/CheckConditions.java
@@ -10,6 +10,16 @@ public class CheckConditions {
     private boolean inventory;
     private boolean ability;
     private boolean passive;
+    private boolean offHand;
+
+    public boolean includesOffHand() {
+        return offHand;
+    }
+
+    public CheckConditions withOffHand(boolean offHand) {
+        this.offHand = offHand;
+        return this;
+    }
 
     public boolean includesAbility() {
         return ability;
@@ -94,6 +104,7 @@ public class CheckConditions {
         this.inventory = all;
         this.ability = all;
         this.passive = all;
+        this.offHand = all;
     }
 
     public static CheckConditions all(){

--- a/src/main/java/game/display/Display.java
+++ b/src/main/java/game/display/Display.java
@@ -212,18 +212,19 @@ public class Display {
     }
 
     @SafeVarargs
-    public static <L extends HasName> void populateMenu(Menu menu, Function<L,UIEventResponse> function, String label,L... l){
+    public static <L extends HasName> List<Pair<Button,L>> populateMenu(Menu menu, Function<L,UIEventResponse> function, String label,L... l){
         List<L> list = new ArrayList<L>();
         for (L l2 : l) {
             list.add(l2);
         }
-        populateMenu(menu, function, label, list);
+        return populateMenu(menu, function, label, list);
     }
 
-    public static <L extends HasName> void populateMenu(Menu menu, Function<L,UIEventResponse> function, String label, Collection<L> list){
+    public static <L extends HasName> List<Pair<Button,L>> populateMenu(Menu menu, Function<L,UIEventResponse> function, String label, Collection<L> list){
         Container container = createFittedContainer(menu.screen,label,list);
-        populateContainer(container, function, list);
+        List<Pair<Button,L>> l = populateContainer(container, function, list);
         menu.screen.addComponent(container);
+        return l;
     }
     
     @SafeVarargs

--- a/src/main/java/game/display/FloorMenu.java
+++ b/src/main/java/game/display/FloorMenu.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-
+import java.util.stream.Collectors;
 import org.hexworks.zircon.api.ComponentDecorations;
 import org.hexworks.zircon.api.builder.component.HeaderBuilder;
 import org.hexworks.zircon.api.builder.component.LabelBuilder;
@@ -48,6 +48,7 @@ import game.gamelogic.floorinteraction.InteractSelector;
 import game.gamelogic.floorinteraction.SelectionResult;
 import game.gamelogic.floorinteraction.Selector;
 import game.gamelogic.floorinteraction.SimpleSelector;
+import game.gamelogic.interactions.HasInteractions;
 import game.gameobjects.DisplayableTile;
 import game.gameobjects.Floor;
 import game.gameobjects.Space;
@@ -639,6 +640,20 @@ public final class FloorMenu extends Menu{
                 break;
             case SKILL_TREES:
                 Display.setMenu(new SkillTreesMenu(currentFloor.getPlayer()));
+                break;
+            case USE:
+                Entity entity = currentFloor.getPlayer();
+                List<HasInteractions> interactables = App.concatStreams(
+                    HasInteractions.gather(entity, false).stream(),
+                    HasInteractions.gather(entity.getSpace()).stream(),
+                    Space.getAdjacentSpaces(entity.getSpace()).stream()
+                        .map(HasInteractions::gather)
+                        .flatMap(c -> c.stream())
+                    )
+                        .collect(Collectors.toList());
+                if (interactables.size() > 0) {
+                    Display.setMenu(new UseMenu(entity, interactables));
+                }
                 break;
             default:
                 return UIEventResponse.pass();

--- a/src/main/java/game/display/FloorMenu.java
+++ b/src/main/java/game/display/FloorMenu.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.hexworks.zircon.api.ComponentDecorations;
 import org.hexworks.zircon.api.builder.component.HeaderBuilder;
 import org.hexworks.zircon.api.builder.component.LabelBuilder;
@@ -643,13 +645,7 @@ public final class FloorMenu extends Menu{
                 Display.setMenu(new SkillTreesMenu(player));
                 break;
             case USE:
-                List<HasInteractions> interactables = App.concatStreams(
-                    HasInteractions.gather(player).stream(),
-                    HasInteractions.gather(player.getSpace()).stream(),
-                    Space.getAdjacentSpaces(player.getSpace()).stream()
-                        .map(HasInteractions::gather)
-                        .flatMap(c -> c.stream()))
-                        .collect(Collectors.toList());
+                List<HasInteractions> interactables = getNearbyInteractables(player).collect(Collectors.toList());
                 if (interactables.size() > 0) {
                     Display.setMenu(new UseMenu(player, interactables));
                 }
@@ -662,6 +658,15 @@ public final class FloorMenu extends Menu{
         }
         update();
         return UIEventResponse.processed();
+    }
+
+    private Stream<HasInteractions> getNearbyInteractables(PlayerEntity player) {
+        return App.concatStreams(
+            HasInteractions.gather(player).stream(),
+            HasInteractions.gather(player.getSpace()).stream(),
+            Space.getAdjacentSpaces(player.getSpace()).stream()
+                .map(HasInteractions::gather)
+                .flatMap(c -> c.stream()));
     }
 
     public int tryMoveToAdjacent(int toX, int toY){

--- a/src/main/java/game/display/FloorMenu.java
+++ b/src/main/java/game/display/FloorMenu.java
@@ -532,8 +532,9 @@ public final class FloorMenu extends Menu{
     
 
     public UIEventResponse handleInGame(KeyboardEvent event, UIEventPhase phase){
+        PlayerEntity player = currentFloor.getPlayer();
         List<OverridesPlayerInput> overridesInput = App.recursiveCheck(
-            currentFloor.getPlayer(),
+            player,
             CheckConditions.none().withStatuses(true),
             (obj -> obj instanceof OverridesPlayerInput op ? Optional.of(op) : Optional.empty())
         );
@@ -600,10 +601,10 @@ public final class FloorMenu extends Menu{
                 break;
             case CENTER: //wait
                 addToLog("waiting...");
-                time = currentFloor.getPlayer().getTimeToWait();
+                time = player.getTimeToWait();
                 break;
             case INTERACT_TOGGLE: //Interact
-                startSelecting(new InteractSelector(currentFloor.getPlayer()));
+                startSelecting(new InteractSelector(player));
                 break;
             case ESCAPE: //pause
                 Display.setMenu(new PauseMenu());
@@ -612,47 +613,45 @@ public final class FloorMenu extends Menu{
                 startSelecting(new ExamineSelector());
                 break;
             case GET_TOGGLE: //getting
-                startSelecting(new GetSelector(currentFloor.getPlayer()));
+                startSelecting(new GetSelector(player));
                 break;
             case EQUIPMENT: //equiping
-                Display.setMenu(EquipmentMenu.createEquipEquipmentMenu(currentFloor.getPlayer()));
+                Display.setMenu(EquipmentMenu.createEquipEquipmentMenu(player));
                 break;
             case DROP_TOGGLE: //dropping
-                startSelecting(new DropSelector(currentFloor.getPlayer()));
+                startSelecting(new DropSelector(player));
                 break;
             case CONSUME: //consuming
-                Display.setMenu(ItemSelectMenu.createConsumableSelectMenu(currentFloor.getPlayer()));
+                Display.setMenu(ItemSelectMenu.createConsumableSelectMenu(player));
                 break;
             case INVENTORY: //inventory
-                Display.setMenu(ItemSelectMenu.createInventoryMenu(currentFloor.getPlayer()));
+                Display.setMenu(ItemSelectMenu.createInventoryMenu(player));
                 break;
             case THROWING: //throwing
-                Display.setMenu(ItemSelectMenu.createThrowMenu(currentFloor.getPlayer()));
+                Display.setMenu(ItemSelectMenu.createThrowMenu(player));
                 break;
             case MEMORY_TOGGLE: //toggle memory
                 toggleMemory();
                 break;
             case ABILITIES:
-                Display.setMenu(new AbilitySelectMenu(currentFloor.getPlayer()));
+                Display.setMenu(new AbilitySelectMenu(player));
                 break;
             case ATTRIBUTES:
-                Display.setMenu(new AttributeMenu(currentFloor.getPlayer()));
+                Display.setMenu(new AttributeMenu(player));
                 break;
             case SKILL_TREES:
-                Display.setMenu(new SkillTreesMenu(currentFloor.getPlayer()));
+                Display.setMenu(new SkillTreesMenu(player));
                 break;
             case USE:
-                Entity entity = currentFloor.getPlayer();
                 List<HasInteractions> interactables = App.concatStreams(
-                    HasInteractions.gather(entity, false).stream(),
-                    HasInteractions.gather(entity.getSpace()).stream(),
-                    Space.getAdjacentSpaces(entity.getSpace()).stream()
+                    HasInteractions.gather(player).stream(),
+                    HasInteractions.gather(player.getSpace()).stream(),
+                    Space.getAdjacentSpaces(player.getSpace()).stream()
                         .map(HasInteractions::gather)
-                        .flatMap(c -> c.stream())
-                    )
+                        .flatMap(c -> c.stream()))
                         .collect(Collectors.toList());
                 if (interactables.size() > 0) {
-                    Display.setMenu(new UseMenu(entity, interactables));
+                    Display.setMenu(new UseMenu(player, interactables));
                 }
                 break;
             default:

--- a/src/main/java/game/display/ItemContextMenu.java
+++ b/src/main/java/game/display/ItemContextMenu.java
@@ -1,5 +1,8 @@
 package game.display;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.hexworks.zircon.api.ComponentDecorations;
 import org.hexworks.zircon.api.builder.component.ButtonBuilder;
 import org.hexworks.zircon.api.builder.component.HeaderBuilder;
@@ -13,10 +16,14 @@ import org.hexworks.zircon.api.graphics.BoxType;
 import org.hexworks.zircon.api.uievent.ComponentEventType;
 import org.hexworks.zircon.api.uievent.UIEventResponse;
 
+import game.Dungeon;
 import game.gamelogic.Consumable;
-import game.gamelogic.Interactable;
+import game.gamelogic.interactions.HasInteractions;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gamelogic.Scrollable;
 import game.gamelogic.floorinteraction.AimSelector;
+import game.gamelogic.floorinteraction.DropDirectSelector;
 import game.gameobjects.ArmorSlot;
 import game.gameobjects.entities.PlayerEntity;
 import game.gameobjects.items.Item;
@@ -26,7 +33,6 @@ import game.gameobjects.items.weapons.Weapon;
 public class ItemContextMenu extends Menu{
 
     private boolean consumable = false;
-    private boolean interactable = false;
     private boolean readable = false;
     private boolean weapon = false;
     private boolean armor = false;
@@ -41,9 +47,9 @@ public class ItemContextMenu extends Menu{
 
         int width = item.getName().length() > 8 ? item.getName().length()+5 : 15;
         int height = 10;
-        if (item instanceof Interactable){
-            height+=2;
-            interactable = true;
+
+        if (item instanceof HasInteractions hi){
+            height += hi.getInteractions().stream().filter(i -> i.isAvailable(playerEntity)).count() * 2;
         }
         if (item instanceof Consumable){
             height+=2;
@@ -204,17 +210,26 @@ public class ItemContextMenu extends Menu{
             pos+=2;
         }
         
-        if (interactable){
-            Button interactButton = new ButtonBuilder()
-                .withText("Interact")
-                .withPosition(2, pos)
-                .build();
-            interactButton.handleComponentEvents(ComponentEventType.ACTIVATED, (event) ->{
-                ((Interactable)item).onInteract(playerEntity);
-                return UIEventResponse.processed();
-            });
-            itemPanel.addComponent(interactButton);
-            pos+=2;
+        if (item instanceof HasInteractions hi) {
+            Collection<Interaction> interactions = hi.getInteractions().stream()
+                .filter(i -> i.isAvailable(playerEntity))
+                .collect(Collectors.toList());
+            for (Interaction interaction : interactions) {
+                Button b = ButtonBuilder.newBuilder()
+                    .withText(interaction.getName())
+                    .withPosition(2, pos)
+                    .build();
+                b.handleComponentEvents(ComponentEventType.ACTIVATED, (event) -> {
+                    InteractionResult res = interaction.doInteract(playerEntity);
+                    if (res.timeTaken() > 0) {
+                        Dungeon.update(res.timeTaken());
+                    }
+                    return UIEventResponse.processed();
+                });
+                itemPanel.addComponent(b);
+                b.setDisabled(interaction.isDisabled(playerEntity));
+                pos+=2;
+            }
         }
 
     }

--- a/src/main/java/game/display/ItemContextMenu.java
+++ b/src/main/java/game/display/ItemContextMenu.java
@@ -221,8 +221,8 @@ public class ItemContextMenu extends Menu{
                     .build();
                 b.handleComponentEvents(ComponentEventType.ACTIVATED, (event) -> {
                     InteractionResult res = interaction.doInteract(playerEntity);
-                    if (res.timeTaken() > 0) {
-                        Dungeon.update(res.timeTaken());
+                    if (res.getTimeTaken() > 0) {
+                        Dungeon.update(res.getTimeTaken());
                     }
                     return UIEventResponse.processed();
                 });

--- a/src/main/java/game/display/ItemContextMenu.java
+++ b/src/main/java/game/display/ItemContextMenu.java
@@ -224,6 +224,9 @@ public class ItemContextMenu extends Menu{
                     if (res.getTimeTaken() > 0) {
                         Dungeon.update(res.getTimeTaken());
                     }
+                    if (res.isRevertMenu()) {
+                        Display.revertMenu();
+                    }
                     return UIEventResponse.processed();
                 });
                 itemPanel.addComponent(b);

--- a/src/main/java/game/display/KeyMap.java
+++ b/src/main/java/game/display/KeyMap.java
@@ -39,6 +39,7 @@ public class KeyMap {
         map.put(KeyCode.KEY_A, Action.ABILITIES);
         map.put(KeyCode.KEY_L, Action.ATTRIBUTES);
         map.put(KeyCode.KEY_S, Action.SKILL_TREES);
+        map.put(KeyCode.KEY_U, Action.USE);
     }
     
     public KeyMap(File keyMapFile){
@@ -101,6 +102,7 @@ public class KeyMap {
         ABILITIES,
         ATTRIBUTES,
         SKILL_TREES,
+        USE,
         NOTHING
     }
 

--- a/src/main/java/game/display/UseMenu.java
+++ b/src/main/java/game/display/UseMenu.java
@@ -1,0 +1,61 @@
+package game.display;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.hexworks.zircon.api.uievent.UIEventResponse;
+
+import game.Dungeon;
+import game.gamelogic.HasName;
+import game.gamelogic.interactions.HasInteractions;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
+import game.gameobjects.entities.Entity;
+
+public class UseMenu extends Menu {
+
+    private Entity interactor;
+    private Collection<HasInteractions> interactables;
+
+    public UseMenu(Entity interactor, Collection<HasInteractions> interactables) {
+        this.interactor = interactor;
+        this.interactables = interactables;
+        Display.populateMenu(
+            this,
+            (obj) -> {
+                if (obj instanceof HasInteractions hasInteractions) {
+                    Collection<Interaction> interactions = hasInteractions.getInteractions().stream()
+                        .filter((i) -> i.isAvailable(interactor))
+                        .collect(Collectors.toList());
+                    if (interactions.size() > 1) {
+                        Display.setMenu(new UseSubMenu(interactor, interactions));
+                    } else {
+                        Optional<Interaction> first = interactions.stream().findFirst();
+                        if (first.isPresent() && !first.get().isDisabled(interactor)) {
+                            InteractionResult result = first.get().doInteract(interactor);
+                            if (result.revertMenu()){
+                                Display.revertMenu();
+                            }
+                            if (result.timeTaken() > 0) {
+                                Dungeon.update(result.timeTaken());
+                                Display.update();
+                            }
+                        }
+                    }
+                }
+                return UIEventResponse.processed();
+            },
+            "Use What?",
+            interactables.stream()
+                .map((i) -> i instanceof HasName hn ? hn : (HasName)() -> i.toString())
+                .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Menu refresh() {
+        return new UseMenu(interactor, interactables);
+    }
+
+}

--- a/src/main/java/game/display/UseMenu.java
+++ b/src/main/java/game/display/UseMenu.java
@@ -34,11 +34,11 @@ public class UseMenu extends Menu {
                         Optional<Interaction> first = interactions.stream().findFirst();
                         if (first.isPresent() && !first.get().isDisabled(interactor)) {
                             InteractionResult result = first.get().doInteract(interactor);
-                            if (result.revertMenu()){
+                            if (result.isRevertMenu()){
                                 Display.revertMenu();
                             }
-                            if (result.timeTaken() > 0) {
-                                Dungeon.update(result.timeTaken());
+                            if (result.getTimeTaken() > 0) {
+                                Dungeon.update(result.getTimeTaken());
                                 Display.update();
                             }
                         }

--- a/src/main/java/game/display/UseSubMenu.java
+++ b/src/main/java/game/display/UseSubMenu.java
@@ -20,16 +20,15 @@ public class UseSubMenu extends Menu {
     public UseSubMenu(Entity interactor, Collection<Interaction> interactions) {
         this.interactor = interactor;
         this.interactions = interactions;
-        // interactions size is guaranteed to be > 1
         List<Pair<Button,Interaction>> pairs = Display.populateMenu(
             this,
             (interaction) -> {
                 InteractionResult result = interaction.doInteract(interactor);
-                if (result.revertMenu()){
+                if (result.isRevertMenu()){
                     Display.revertMenu();
                 }
-                if (result.timeTaken() > 0) {
-                    Dungeon.update(result.timeTaken());
+                if (result.getTimeTaken() > 0) {
+                    Dungeon.update(result.getTimeTaken());
                     Display.update();
                 }
                 return UIEventResponse.processed();

--- a/src/main/java/game/display/UseSubMenu.java
+++ b/src/main/java/game/display/UseSubMenu.java
@@ -1,0 +1,51 @@
+package game.display;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.hexworks.zircon.api.component.Button;
+import org.hexworks.zircon.api.uievent.UIEventResponse;
+
+import game.Dungeon;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
+import game.gameobjects.entities.Entity;
+import kotlin.Pair;
+
+public class UseSubMenu extends Menu {
+
+    private Entity interactor;
+    private Collection<Interaction> interactions;
+
+    public UseSubMenu(Entity interactor, Collection<Interaction> interactions) {
+        this.interactor = interactor;
+        this.interactions = interactions;
+        // interactions size is guaranteed to be > 1
+        List<Pair<Button,Interaction>> pairs = Display.populateMenu(
+            this,
+            (interaction) -> {
+                InteractionResult result = interaction.doInteract(interactor);
+                if (result.revertMenu()){
+                    Display.revertMenu();
+                }
+                if (result.timeTaken() > 0) {
+                    Dungeon.update(result.timeTaken());
+                    Display.update();
+                }
+                return UIEventResponse.processed();
+            },
+            "Use How?",
+            interactions
+        );
+        for (Pair<Button,Interaction> pair : pairs) {
+            pair.getFirst().setDisabled(pair.getSecond().isDisabled(interactor));
+        }
+    }
+
+    @Override
+    public Menu refresh() {
+        return new UseSubMenu(interactor, interactions);
+    }
+
+}
+

--- a/src/main/java/game/floorgeneration/DebugFloorGenerator.java
+++ b/src/main/java/game/floorgeneration/DebugFloorGenerator.java
@@ -4,7 +4,9 @@ import java.util.function.Supplier;
 
 import game.PathConditions;
 import game.gamelogic.Examinable;
-import game.gamelogic.Interactable;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gamelogic.SelfAware;
 import game.gamelogic.behavior.Behavable;
 import game.gameobjects.Space;
@@ -173,7 +175,7 @@ public class DebugFloorGenerator extends FloorGenerator {
 
     }
 
-    private class DebugSpawner extends Terrain implements Examinable, Behavable, SelfAware, Interactable{
+    private class DebugSpawner extends Terrain implements Examinable, Behavable, SelfAware, HasInteraction{
 
         private Supplier<Entity> generator;
         private int timer;
@@ -232,8 +234,14 @@ public class DebugFloorGenerator extends FloorGenerator {
         }
 
         @Override
-        public void onInteract(Entity interactor) {
-            this.toggled = !this.toggled;
+        public Interaction getInteraction() {
+            return new Interaction.Builder()
+                .withName("Toggle")
+                .withOnInteract((ent) -> {
+                    this.toggled = !this.toggled;
+                    return InteractionResult.create();
+                })
+                .build();
         }
 
     }

--- a/src/main/java/game/gamelogic/Interactable.java
+++ b/src/main/java/game/gamelogic/Interactable.java
@@ -1,7 +1,0 @@
-package game.gamelogic;
-
-import game.gameobjects.entities.Entity;
-
-public interface Interactable {
-    public void onInteract(Entity interactor);
-}

--- a/src/main/java/game/gamelogic/floorinteraction/DropDirectSelector.java
+++ b/src/main/java/game/gamelogic/floorinteraction/DropDirectSelector.java
@@ -1,8 +1,6 @@
-package game.display;
+package game.gamelogic.floorinteraction;
 
 import game.gamelogic.HasInventory;
-import game.gamelogic.floorinteraction.SelectionResult;
-import game.gamelogic.floorinteraction.SimpleSelector;
 import game.gameobjects.Space;
 import game.gameobjects.items.Item;
 

--- a/src/main/java/game/gamelogic/floorinteraction/InteractSelector.java
+++ b/src/main/java/game/gamelogic/floorinteraction/InteractSelector.java
@@ -35,7 +35,7 @@ public class InteractSelector implements SimpleSelector{
                     Optional<Interaction> fInter = interactions.stream().findFirst();
                     if (fInter.isPresent()) {
                         InteractionResult result = fInter.get().doInteract(entity);
-                        return new SelectionResult(true, result.timeTaken());
+                        return new SelectionResult(true, result.getTimeTaken());
                     }
                 }
             }

--- a/src/main/java/game/gamelogic/interactions/HasInteraction.java
+++ b/src/main/java/game/gamelogic/interactions/HasInteraction.java
@@ -1,0 +1,16 @@
+package game.gamelogic.interactions;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public interface HasInteraction extends HasInteractions{
+    public Interaction getInteraction();
+    @Override
+    default Collection<Interaction> getInteractions() {
+        Interaction interaction = getInteraction();
+        if (interaction != null)
+            return List.of(interaction);
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/game/gamelogic/interactions/HasInteractions.java
+++ b/src/main/java/game/gamelogic/interactions/HasInteractions.java
@@ -1,0 +1,38 @@
+package game.gamelogic.interactions;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import game.App;
+import game.CheckConditions;
+import game.gameobjects.Space;
+import game.gameobjects.entities.Entity;
+
+public interface HasInteractions {
+    public Collection<Interaction> getInteractions();
+
+    public static Collection<HasInteractions> gather(Space space){
+        return App.concatStreams(
+            toInteractable(space.isOccupied() ? Stream.of(space.getOccupant()) : Stream.empty()),
+            toInteractable(space.getItems().stream()),
+            toInteractable(space.getTerrains().stream())
+        ).collect(Collectors.toList());
+    }
+
+    private static Stream<HasInteractions> toInteractable(Stream<?> stream){
+        return stream
+            .filter(o -> o instanceof HasInteractions)
+            .map(o -> (HasInteractions)o);
+    }
+
+    public static Collection<HasInteractions> gather(Entity entity, boolean include){
+        return App.recursiveCheck(
+            entity,
+            CheckConditions.none().withInventory(true).withOffHand(true),
+            obj -> obj instanceof HasInteractions ha ? Optional.of(ha) : Optional.empty()
+        ).stream().filter(r -> include ? true : r != entity).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/game/gamelogic/interactions/HasInteractions.java
+++ b/src/main/java/game/gamelogic/interactions/HasInteractions.java
@@ -27,12 +27,12 @@ public interface HasInteractions {
             .map(o -> (HasInteractions)o);
     }
 
-    public static Collection<HasInteractions> gather(Entity entity, boolean include){
+    public static Collection<HasInteractions> gather(Entity entity){
         return App.recursiveCheck(
             entity,
             CheckConditions.none().withInventory(true).withOffHand(true),
             obj -> obj instanceof HasInteractions ha ? Optional.of(ha) : Optional.empty()
-        ).stream().filter(r -> include ? true : r != entity).collect(Collectors.toList());
+        ).stream().filter(r -> r != entity).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/game/gamelogic/interactions/Interaction.java
+++ b/src/main/java/game/gamelogic/interactions/Interaction.java
@@ -1,0 +1,74 @@
+package game.gamelogic.interactions;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import game.gamelogic.HasName;
+import game.gameobjects.entities.Entity;
+
+public interface Interaction extends HasName{
+
+    public InteractionResult doInteract(Entity interactor);
+
+    default boolean isDisabled(Entity interactor){
+        return false;
+    }
+
+    default boolean isAvailable(Entity interactor){
+        return true;
+    }
+
+    public class Builder{
+
+        public Function<Entity, InteractionResult> onInteract = (entity) -> InteractionResult.create();
+        public Predicate<Entity> isDisabled = (entity) -> false;
+        public Predicate<Entity> isAvailable = (entity) -> true;
+        public String name = "";
+
+        public Builder(){}
+
+        public Builder withOnInteract(Function<Entity, InteractionResult> onInteract){
+            this.onInteract = onInteract;
+            return this;
+        }
+
+        public Builder withIsDisabled(Predicate<Entity> isDisabled){
+            this.isDisabled = isDisabled;
+            return this;
+        }
+
+        public Builder withIsAvailable(Predicate<Entity> isAvailable){
+            this.isAvailable = isAvailable;
+            return this;
+        }
+
+        public Builder withName(String name){
+            this.name = name;
+            return this;
+        }
+
+        public Interaction build(){
+            return new Interaction(){
+                @Override
+                public String getName() {
+                    return Builder.this.name;
+                }
+
+                @Override
+                public InteractionResult doInteract(Entity interactor) {
+                    return Builder.this.onInteract.apply(interactor);
+                }
+
+                @Override 
+                public boolean isDisabled(Entity interactor) {
+                    return Builder.this.isDisabled.test(interactor);
+                }
+
+                @Override 
+                public boolean isAvailable(Entity interactor) {
+                    return Builder.this.isAvailable.test(interactor);
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/game/gamelogic/interactions/InteractionResult.java
+++ b/src/main/java/game/gamelogic/interactions/InteractionResult.java
@@ -6,11 +6,11 @@ public class InteractionResult {
 
     private boolean revertMenu = false;
 
-    public int timeTaken() {
+    public int getTimeTaken() {
         return timeTaken;
     }
 
-    public boolean revertMenu() {
+    public boolean isRevertMenu() {
         return revertMenu;
     }
 

--- a/src/main/java/game/gamelogic/interactions/InteractionResult.java
+++ b/src/main/java/game/gamelogic/interactions/InteractionResult.java
@@ -1,0 +1,32 @@
+package game.gamelogic.interactions;
+
+public class InteractionResult {
+
+    private int timeTaken = 0;
+
+    private boolean revertMenu = false;
+
+    public int timeTaken() {
+        return timeTaken;
+    }
+
+    public boolean revertMenu() {
+        return revertMenu;
+    }
+
+    public static InteractionResult create(){
+        return new InteractionResult();
+    }
+
+    public InteractionResult withTimeTaken(int timeTaken) {
+        this.timeTaken = timeTaken;
+        return this;
+    }
+
+    public InteractionResult withRevertMenu() {
+        this.revertMenu = true;
+        return this;
+    }
+
+}
+

--- a/src/main/java/game/gamelogic/interactions/OpenInvInteraction.java
+++ b/src/main/java/game/gamelogic/interactions/OpenInvInteraction.java
@@ -1,0 +1,6 @@
+package game.gamelogic.interactions;
+
+public class OpenInvInteraction {
+
+    
+}

--- a/src/main/java/game/gamelogic/interactions/OpenInventoryInteraction.java
+++ b/src/main/java/game/gamelogic/interactions/OpenInventoryInteraction.java
@@ -1,0 +1,33 @@
+package game.gamelogic.interactions;
+
+import game.display.Display;
+import game.display.ItemSelectMenu;
+import game.gamelogic.HasInventory;
+import game.gamelogic.HasName;
+import game.gameobjects.entities.Entity;
+
+public class OpenInventoryInteraction implements Interaction {
+
+    private HasInventory inventoryToOpen;
+
+    public OpenInventoryInteraction(HasInventory inventoryToOpen) {
+        this.inventoryToOpen = inventoryToOpen;
+    }
+
+    @Override
+    public String getName() {
+        return "Open" + (inventoryToOpen instanceof HasName hn ? " " + hn.getName() : "");
+    }
+
+    @Override
+    public InteractionResult doInteract(Entity interactor) {
+        if (interactor instanceof HasInventory interactorWithInventory){
+            Display.setMenu(
+                ItemSelectMenu.createInventoryTransferMenu(inventoryToOpen, interactorWithInventory)
+            );
+        }
+        return InteractionResult.create()
+            .withTimeTaken(100);
+    }
+
+}

--- a/src/main/java/game/gameobjects/entities/Door.java
+++ b/src/main/java/game/gameobjects/entities/Door.java
@@ -6,8 +6,10 @@ import org.hexworks.zircon.api.color.TileColor;
 
 import game.gamelogic.Flammable;
 import game.gamelogic.HasResistances;
-import game.gamelogic.Interactable;
 import game.gamelogic.SelfAware;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gamelogic.resistances.PercentageResistance;
 import game.gamelogic.resistances.Resistance;
 import game.gameobjects.DamageType;
@@ -17,7 +19,7 @@ import game.gameobjects.statuses.Burning;
 import game.gameobjects.statuses.Status;
 import game.gameobjects.terrains.OpenDoor;
 
-public class Door extends Entity implements Interactable, HasResistances{
+public class Door extends Entity implements HasResistances, HasInteraction{
     
     public Door(Character c){
         super(TileColor.transparent(), TileColor.create(181, 88, 45, 255), c);
@@ -92,16 +94,27 @@ public class Door extends Entity implements Interactable, HasResistances{
 
     }
 
-    @Override
-    public void onInteract(Entity interactor) {
+    public int openDoor(Entity entity){
         getSpace().setOccupant(null);
         getSpace().addTerrain(new OpenDoor(this));
+        return entity.getTimeToMove();
     }
 
     @Override
     public int defaultInteraction(Entity interactor) {
-        onInteract(interactor);
-        return interactor.getTimeToMove();
+        return openDoor(interactor);
+    }
+
+    @Override
+    public Interaction getInteraction() {
+        return new Interaction.Builder()
+            .withName("Open")
+            .withOnInteract((interactor) -> {
+                return InteractionResult.create()
+                    .withTimeTaken(openDoor(interactor))
+                    .withRevertMenu();
+            })
+            .build();
     }
 
     @Override
@@ -123,5 +136,5 @@ public class Door extends Entity implements Interactable, HasResistances{
     protected boolean baseVulnerable(Status status) {
         return status instanceof Burning;
     }
-    
+
 }

--- a/src/main/java/game/gameobjects/entities/Mimic.java
+++ b/src/main/java/game/gameobjects/entities/Mimic.java
@@ -12,9 +12,11 @@ import game.App;
 import game.display.Display;
 import game.gamelogic.DropsXP;
 import game.gamelogic.HasInventory;
-import game.gamelogic.Interactable;
 import game.gamelogic.behavior.AnimalHunting;
 import game.gamelogic.combat.Attack;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gameobjects.DamageType;
 import game.gameobjects.items.Item;
 import game.gameobjects.items.weapons.Weapon;
@@ -22,7 +24,7 @@ import game.gameobjects.statuses.PseudoStatus;
 import game.gameobjects.statuses.Sleeping;
 import game.gameobjects.statuses.Status;
 
-public class Mimic extends Animal implements Interactable, DropsXP, HasInventory{
+public class Mimic extends Animal implements DropsXP, HasInventory, HasInteraction{
 
     private boolean activated;
     private int activeTimer;
@@ -130,15 +132,6 @@ public class Mimic extends Animal implements Interactable, DropsXP, HasInventory
         return super.isActive() && activated;
     }
 
-    @Override
-    public int defaultInteraction(Entity interactor) {
-        if (!activated) {
-            activate(interactor);
-            return interactor.getTimeToWait();
-        }
-        return super.defaultInteraction(interactor);
-    }
-
     private void activate(Entity activator){
         Display.log("The " + getName() + " is a mimic!", getSpace());
         activated = true;
@@ -172,9 +165,12 @@ public class Mimic extends Animal implements Interactable, DropsXP, HasInventory
     }
 
     @Override
-    public void onInteract(Entity interactor) {
-        if (!activated)
+    public int defaultInteraction(Entity interactor) {
+        if (!activated) {
             activate(interactor);
+            return interactor.getTimeToWait();
+        }
+        return super.defaultInteraction(interactor);
     }
 
     @Override
@@ -190,6 +186,19 @@ public class Mimic extends Animal implements Interactable, DropsXP, HasInventory
     @Override
     public int getHardWeightLimit() {
         return 999;
+    }
+
+    @Override
+    public Interaction getInteraction() {
+        return new Interaction.Builder()
+            .withName("???")
+            .withOnInteract((interactor) -> {
+                if (!activated)
+                    activate(interactor);
+                return InteractionResult.create()
+                    .withTimeTaken(interactor.getTimeToWait());
+            })
+            .build();
     }
 
 }

--- a/src/main/java/game/gameobjects/entities/Mimic.java
+++ b/src/main/java/game/gameobjects/entities/Mimic.java
@@ -196,7 +196,8 @@ public class Mimic extends Animal implements DropsXP, HasInventory, HasInteracti
                 if (!activated)
                     activate(interactor);
                 return InteractionResult.create()
-                    .withTimeTaken(interactor.getTimeToWait());
+                    .withTimeTaken(interactor.getTimeToWait())
+                    .withRevertMenu();
             })
             .build();
     }

--- a/src/main/java/game/gameobjects/entities/props/ContainerProp.java
+++ b/src/main/java/game/gameobjects/entities/props/ContainerProp.java
@@ -7,11 +7,12 @@ import org.hexworks.zircon.api.color.TileColor;
 
 import game.Dungeon;
 import game.display.Display;
-import game.display.ItemSelectMenu;
 import game.gamelogic.Attribute;
 import game.gamelogic.HasInventory;
 import game.gamelogic.HasResistances;
-import game.gamelogic.Interactable;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.OpenInventoryInteraction;
 import game.gamelogic.resistances.PercentageResistance;
 import game.gamelogic.resistances.Resistance;
 import game.gameobjects.DamageType;
@@ -20,7 +21,7 @@ import game.gameobjects.entities.Entity;
 import game.gameobjects.entities.PlayerEntity;
 import game.gameobjects.items.Item;
 
-public abstract class ContainerProp extends Entity implements Interactable, HasInventory, HasResistances{
+public abstract class ContainerProp extends Entity implements HasInteraction, HasInventory, HasResistances{
 
     private List<Item> inventory = new ArrayList<Item>();
 
@@ -72,13 +73,6 @@ public abstract class ContainerProp extends Entity implements Interactable, HasI
     }
 
     @Override
-    public void onInteract(Entity interactor) {
-        if (interactor instanceof HasInventory interactorWithInventory){
-            Display.setMenu(ItemSelectMenu.createInventoryTransferMenu(this, interactorWithInventory));
-        }
-    }
-
-    @Override
     public String getDeathMessage() {
         return "The " + getName() + " breaks.";
     }
@@ -94,4 +88,10 @@ public abstract class ContainerProp extends Entity implements Interactable, HasI
         }
         return rList;
     }
+
+    @Override
+    public Interaction getInteraction() {
+        return new OpenInventoryInteraction(this);
+    }
+
 }

--- a/src/main/java/game/gameobjects/items/Torch.java
+++ b/src/main/java/game/gameobjects/items/Torch.java
@@ -120,7 +120,6 @@ public class Torch extends Weapon implements Flammable, LightSource, SelfAware, 
                         setLit();
                     }
                     return InteractionResult.create()
-                        .withTimeTaken(0)
                         .withRevertMenu();
                 })
                 .withIsDisabled((interactor) -> {
@@ -132,7 +131,6 @@ public class Torch extends Weapon implements Flammable, LightSource, SelfAware, 
                 .withOnInteract((interactor) -> {
                     Display.getRootMenu().startSelecting(new KindleSelector());
                     return InteractionResult.create()
-                        .withTimeTaken(0)
                         .withRevertMenu();
                 })
                 .withIsDisabled((interactor) -> {

--- a/src/main/java/game/gameobjects/items/Torch.java
+++ b/src/main/java/game/gameobjects/items/Torch.java
@@ -1,24 +1,30 @@
 package game.gameobjects.items;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.hexworks.zircon.api.color.TileColor;
 
 import game.App;
 import game.display.Display;
-import game.display.ItemContextMenu;
 import game.gamelogic.Flammable;
-import game.gamelogic.Interactable;
 import game.gamelogic.LightSource;
 import game.gamelogic.SelfAware;
 import game.gamelogic.behavior.Behavable;
 import game.gamelogic.combat.Attack;
 import game.gamelogic.combat.AttackModifier;
+import game.gamelogic.floorinteraction.SelectionResult;
+import game.gamelogic.floorinteraction.SimpleSelector;
+import game.gamelogic.interactions.HasInteractions;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gameobjects.DamageType;
 import game.gameobjects.Space;
-import game.gameobjects.entities.Entity;
 import game.gameobjects.items.weapons.Weapon;
 import game.gameobjects.statuses.Burning;
+import game.gameobjects.terrains.Fire;
 
-public class Torch extends Weapon implements Flammable, LightSource, SelfAware, Behavable, Interactable, AttackModifier{
+public class Torch extends Weapon implements Flammable, LightSource, SelfAware, Behavable, AttackModifier, HasInteractions{
     
     private boolean lit = false;
     private int maxFuel = 500;
@@ -83,12 +89,20 @@ public class Torch extends Weapon implements Flammable, LightSource, SelfAware, 
     @Override
     public int behave() {
         if (lit) {
-            fuel--;
-        }
-        if (fuel <= 0) {
-            setBurnt();
+            decrementFuel();
         }
         return 100;
+    }
+
+    private void decrementFuel(){
+        decrementFuel(1);
+    }
+
+    private void decrementFuel(int amount){
+        this.fuel -= amount;
+        if (this.fuel <= 0) {
+            setBurnt();
+        }
     }
 
     @Override
@@ -97,14 +111,35 @@ public class Torch extends Weapon implements Flammable, LightSource, SelfAware, 
     }
 
     @Override
-    public void onInteract(Entity interactor) {
-        if (!lit){
-            setLit();
-        } else {
-            Display.log("The torch is already lit.");
-        }
-        if (Display.getCurrentMenu() instanceof ItemContextMenu)
-            Display.revertMenu();
+    public Collection<Interaction> getInteractions() {
+        return List.of(
+            new Interaction.Builder()
+                .withName("Light")
+                .withOnInteract((interactor) -> {
+                    if (!lit){
+                        setLit();
+                    }
+                    return InteractionResult.create()
+                        .withTimeTaken(0)
+                        .withRevertMenu();
+                })
+                .withIsDisabled((interactor) -> {
+                    return lit || fuel <= 0;
+                })
+                .build(),
+            new Interaction.Builder()
+                .withName("Kindle")
+                .withOnInteract((interactor) -> {
+                    Display.getRootMenu().startSelecting(new KindleSelector());
+                    return InteractionResult.create()
+                        .withTimeTaken(0)
+                        .withRevertMenu();
+                })
+                .withIsDisabled((interactor) -> {
+                    return !lit;
+                })
+                .build()
+        );
     }
 
     private void setLit(){
@@ -140,6 +175,20 @@ public class Torch extends Weapon implements Flammable, LightSource, SelfAware, 
             if (attackResult.weapon() == this && attackResult.hit() && attackResult.crit() && lit)
                 attackResult.defender().addStatus(new Burning());
         });
+    }
+
+    private class KindleSelector implements SimpleSelector {
+
+        @Override
+        public SelectionResult simpleSelect(Space space) {
+            if (Torch.this.lit && Fire.isFlammable(space)) {
+                Torch.this.decrementFuel(100);
+                space.addFire(new Fire(1));
+                return new SelectionResult(true, 100);
+            }
+            return new SelectionResult(true, 0);
+        }
+
     }
 
 }

--- a/src/main/java/game/gameobjects/terrains/Ashes.java
+++ b/src/main/java/game/gameobjects/terrains/Ashes.java
@@ -3,12 +3,10 @@ package game.gameobjects.terrains;
 import org.hexworks.zircon.api.color.TileColor;
 
 import game.gamelogic.Examinable;
-import game.gamelogic.Interactable;
 import game.gamelogic.SelfAware;
 import game.gameobjects.Space;
-import game.gameobjects.entities.Entity;
 
-public class Ashes extends Terrain implements Examinable, Interactable, SelfAware {
+public class Ashes extends Terrain implements Examinable, SelfAware {
 
     private Space space;
 
@@ -22,11 +20,6 @@ public class Ashes extends Terrain implements Examinable, Interactable, SelfAwar
     @Override
     public String getName() {
         return "Ashes";
-    }
-
-    @Override
-    public void onInteract(Entity interactor) {
-
     }
 
     @Override

--- a/src/main/java/game/gameobjects/terrains/OpenDoor.java
+++ b/src/main/java/game/gameobjects/terrains/OpenDoor.java
@@ -7,18 +7,17 @@ import org.hexworks.zircon.api.color.TileColor;
 import game.display.Display;
 import game.gamelogic.Examinable;
 import game.gamelogic.Flammable;
-import game.gamelogic.Interactable;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gameobjects.DamageType;
 import game.gameobjects.entities.Door;
 import game.gameobjects.entities.Entity;
 import game.gameobjects.statuses.Burning;
 
-public class OpenDoor extends Terrain implements Interactable, Examinable, Flammable{
+public class OpenDoor extends Terrain implements Examinable, Flammable, HasInteraction{
     
     private Door door;
-    public String name;
-    public String description;
-    public String stats;
 
     public OpenDoor(Door door){
         super(TileColor.transparent(), TileColor.create(181, 88, 45, 255), '\\');
@@ -26,15 +25,27 @@ public class OpenDoor extends Terrain implements Interactable, Examinable, Flamm
         this.door = door;
     }
 
-    @Override
-    public void onInteract(Entity interactor) {
+    public int closeDoor(Entity interactor){
         if (door.getSpace().isOccupied()){
-            Display.log("Something is in the way.");
-        } else {
-            door.getSpace().removeTerrain(this);
-            door.getSpace().setOccupant(door);
-            Display.update();
+            Display.log("Something is in the way.", door.getSpace());
+            return 0;
         }
+        door.getSpace().removeTerrain(this);
+        door.getSpace().setOccupant(door);
+        Display.update();
+        return interactor.getTimeToMove();
+    }
+
+    @Override
+    public Interaction getInteraction() {
+        return new Interaction.Builder()
+            .withName("Close")
+            .withOnInteract((interactor) -> {
+                return InteractionResult.create()
+                    .withTimeTaken(closeDoor(interactor))
+                    .withRevertMenu();
+            })
+            .build();
     }
 
     @Override

--- a/src/main/java/game/gameobjects/terrains/Staircase.java
+++ b/src/main/java/game/gameobjects/terrains/Staircase.java
@@ -4,12 +4,13 @@ import org.hexworks.zircon.api.color.TileColor;
 
 import game.Dungeon;
 import game.gamelogic.Examinable;
-import game.gamelogic.Interactable;
 import game.gamelogic.SelfAware;
+import game.gamelogic.interactions.HasInteraction;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gameobjects.Space;
-import game.gameobjects.entities.Entity;
 
-public class Staircase extends Terrain implements SelfAware, Interactable, Examinable{
+public class Staircase extends Terrain implements SelfAware, HasInteraction, Examinable{
 
     private Space space;
     private String name = "Staircase";
@@ -33,11 +34,6 @@ public class Staircase extends Terrain implements SelfAware, Interactable, Exami
     }
 
     @Override
-    public void onInteract(Entity interactor) {
-        Dungeon.goDownFloor(this);
-    }
-
-    @Override
     public String getName() {
         return name;
     }
@@ -45,6 +41,18 @@ public class Staircase extends Terrain implements SelfAware, Interactable, Exami
     @Override
     public String getDescription() {
         return description;
+    }
+
+    @Override
+    public Interaction getInteraction() {
+        return new Interaction.Builder()
+            .withName("Descend")
+            .withOnInteract((interactor) -> {
+                Dungeon.goDownFloor(Staircase.this);
+                return InteractionResult.create()
+                    .withTimeTaken(0);
+            })
+            .build();
     }
     
 }

--- a/src/main/java/game/gameobjects/terrains/Staircase.java
+++ b/src/main/java/game/gameobjects/terrains/Staircase.java
@@ -49,8 +49,7 @@ public class Staircase extends Terrain implements SelfAware, HasInteraction, Exa
             .withName("Descend")
             .withOnInteract((interactor) -> {
                 Dungeon.goDownFloor(Staircase.this);
-                return InteractionResult.create()
-                    .withTimeTaken(0);
+                return InteractionResult.create();
             })
             .build();
     }

--- a/src/main/java/game/gameobjects/terrains/Trapdoor.java
+++ b/src/main/java/game/gameobjects/terrains/Trapdoor.java
@@ -4,8 +4,9 @@ import org.hexworks.zircon.api.color.TileColor;
 
 import game.display.Display;
 import game.gamelogic.HasInventory;
+import game.gamelogic.interactions.Interaction;
+import game.gamelogic.interactions.InteractionResult;
 import game.gameobjects.Space;
-import game.gameobjects.entities.Entity;
 import game.gameobjects.items.Item;
 
 public class Trapdoor extends Staircase {
@@ -31,27 +32,29 @@ public class Trapdoor extends Staircase {
     }
 
     @Override
-    public void onInteract(Entity interactor) {
-        boolean opening = false;
-        HasInventory inventoryHaver = null;
-        if (interactor instanceof HasInventory hasInventory) {
-            for (Item item : hasInventory.getInventory()) {
-                if (item == keyItem) {
-                    opening = true;
-                    inventoryHaver = hasInventory;
+    public Interaction getInteraction(){
+        return new Interaction.Builder()
+            .withOnInteract((interactor) -> {
+                if (interactor instanceof HasInventory hasInventory) {
+                    for (Item item : hasInventory.getInventory()) {
+                        if (item == keyItem) {
+                            Display.log("You unlock the trapdoor.");
+                            hasInventory.removeItemFromInventory(keyItem);
+                            Space space = getSpace();
+                            space.remove(this);
+                            space.addTerrain(staircase);
+                            return InteractionResult.create()
+                                .withRevertMenu();
+                        }
+                    }
                 }
-            }
-        }
-        if (opening) {
-            Display.log("You unlock the trapdoor.");
-            inventoryHaver.removeItemFromInventory(keyItem);
-            Space space = getSpace();
-            space.remove(this);
-            space.addTerrain(staircase);
-            return;
-        } else {
-            Display.log("The trapdoor is locked.");
-            return;
-        }
+                Display.log("The trapdoor is locked.");
+                return InteractionResult.create()
+                    .withRevertMenu();
+            })
+            .withName("Unlock")
+            .build();
     }
+
+    
 }


### PR DESCRIPTION
Encapsulates interactions entities can have with other Entities/Terrains/Items via the `Interaction` type. Objects with interactions should now implement the `HasInteractions` and `HasInteraction` interfaces.
Adds a new `USE` action binded to `u` by default. This collects nearby Interactables and displays them in a new `UseMenu`.
Interactables with multiple interactions now open a new `UseSubMenu` when the player tries to interact with them, which allows them to choose a specific interaction to use.